### PR TITLE
chore(rust): restore quality baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
@@ -46,8 +46,8 @@ jobs:
         # - macos-latest
         # - windows-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
@@ -59,7 +59,7 @@ jobs:
     - name: Build ✨
       run: cargo build --release
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ github.event.repository.name }}-${{ matrix.os }}
         path: target/release/${{ github.event.repository.name }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}

--- a/references/basic-sample/packages/py-lib2/Makefile
+++ b/references/basic-sample/packages/py-lib2/Makefile
@@ -1,2 +1,2 @@
 format:
-	poetry run echo "Format competed!"
+	echo "Format completed!"

--- a/src/bin/mrt/commands/list.rs
+++ b/src/bin/mrt/commands/list.rs
@@ -1,46 +1,44 @@
 use clap::Args;
-use serde::{Serialize, Deserialize};
-use tabled::{Table, Style};
+use serde::{Deserialize, Serialize};
+use tabled::{Style, Table};
 
 use mrt::package::Package;
 
-use super::{CommandResult, CommandExec};
+use super::{CommandExec, CommandResult};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListResult {
-    packages: Vec<Package>
+    packages: Vec<Package>,
 }
 
 impl CommandResult<ListResult> for ListResult {
     fn get_result(&self) -> &ListResult {
-        &self
+        self
     }
 }
 
 #[derive(Args)]
 pub struct ListArgs {
-    #[arg(short, long, default_value_t=false)]
-    pub all: bool
+    #[arg(short, long, default_value_t = false)]
+    pub all: bool,
 }
 
 impl CommandExec<ListResult> for ListArgs {
-    fn exec(&self, context: &impl super::CommandExecutionContext) -> Box<dyn CommandResult<ListResult>> {
-
+    fn exec(
+        &self,
+        context: &impl super::CommandExecutionContext,
+    ) -> Box<dyn CommandResult<ListResult>> {
         let packages = context.get_project().get_packages(self.all);
 
         let result = ListResult { packages };
 
-        match context.get_cli().is_interactive() {
-            true => {
-                let mut table = Table::new(&result.packages);
-                table
-                    .with(Style::blank());
+        if context.get_cli().is_interactive() {
+            let mut table = Table::new(&result.packages);
+            table.with(Style::blank());
 
-                println!("{}", table);
-            },
-            false => ()
+            println!("{}", table);
         };
 
-        return Box::from(result);
+        Box::from(result)
     }
 }

--- a/src/bin/mrt/commands/mod.rs
+++ b/src/bin/mrt/commands/mod.rs
@@ -1,7 +1,7 @@
-use indicatif::{ProgressBar};
+use indicatif::ProgressBar;
 use serde::ser;
 
-use mrt::{project::Project, progress::ProgressReporter};
+use mrt::{progress::ProgressReporter, project::Project};
 
 use crate::Cli;
 
@@ -14,17 +14,21 @@ pub trait CommandExecutionContext {
 }
 
 pub trait CommandExec<T>
-    where T: ser::Serialize {
-        fn exec(&self, context: &impl CommandExecutionContext) -> Box<dyn CommandResult<T>>;
+where
+    T: ser::Serialize,
+{
+    fn exec(&self, context: &impl CommandExecutionContext) -> Box<dyn CommandResult<T>>;
 }
 
-pub trait CommandResult<T> 
-    where T: ser::Serialize {
+pub trait CommandResult<T>
+where
+    T: ser::Serialize,
+{
     fn get_result(&self) -> &T;
 }
 
 pub(super) struct ProgressBarReporter<'a> {
-    pub progress_bar: &'a ProgressBar
+    pub progress_bar: &'a ProgressBar,
 }
 
 impl<'a> ProgressReporter for ProgressBarReporter<'a> {
@@ -33,10 +37,8 @@ impl<'a> ProgressReporter for ProgressBarReporter<'a> {
     }
 }
 
-pub(super) struct NoopProgressReporter {
-}
+pub(super) struct NoopProgressReporter {}
 
 impl ProgressReporter for NoopProgressReporter {
-    fn report_output(&self, _message: &str) {
-    }
+    fn report_output(&self, _message: &str) {}
 }

--- a/src/bin/mrt/commands/run_script.rs
+++ b/src/bin/mrt/commands/run_script.rs
@@ -3,31 +3,31 @@ use std::time::Duration;
 
 use anyhow::Result;
 use clap::Args;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use console::style;
-use serde::{Serialize, Deserialize};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use serde::{Deserialize, Serialize};
 
 use mrt::archetypes::get_archetype_by_id;
+use mrt::package::Package;
 use mrt::progress::ProgressReporter;
-use mrt::{package::Package};
-use mrt::runners::{ScriptRunResult, ScriptRunContext, ScriptRunResultType};
+use mrt::runners::{ScriptRunContext, ScriptRunResult, ScriptRunResultType};
 
-use super::{CommandResult, ProgressBarReporter, CommandExec, NoopProgressReporter};
+use super::{CommandExec, CommandResult, NoopProgressReporter, ProgressBarReporter};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PackageResult<TResult> {
     pub package: Package,
-    pub result: TResult
+    pub result: TResult,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RunScriptResult {
-    results: Vec<PackageResult<ScriptRunResult>>
+    results: Vec<PackageResult<ScriptRunResult>>,
 }
 
 impl CommandResult<RunScriptResult> for RunScriptResult {
     fn get_result(&self) -> &RunScriptResult {
-        &self
+        self
     }
 }
 
@@ -35,32 +35,33 @@ impl CommandResult<RunScriptResult> for RunScriptResult {
 pub struct RunScriptArgs {
     /// Name of the script to run
     #[arg(index = 1)]
-    pub script_spec: String
+    pub script_spec: String,
 }
 
-fn exec_package(package: &Package, script_spec: &str, reporter: &impl ProgressReporter) -> Result<ScriptRunResult> {
+fn exec_package(
+    package: &Package,
+    script_spec: &str,
+    reporter: &impl ProgressReporter,
+) -> Result<ScriptRunResult> {
     let script_runner = get_archetype_by_id(package.archetype_id.as_str())
         .unwrap()
         .get_script_runner();
 
-    let result = script_runner.run_script(&ScriptRunContext {
+    script_runner.run_script(&ScriptRunContext {
         script_spec,
         package,
-        reporter
-    });
-
-    return result;
+        reporter,
+    })
 }
 
 impl RunScriptArgs {
-
-    fn exec_interactive(&self, packages: &Vec<Package>) -> Vec<PackageResult<ScriptRunResult>> {
+    fn exec_interactive(&self, packages: &[Package]) -> Vec<PackageResult<ScriptRunResult>> {
         let spinner_style = ProgressStyle::with_template("{prefix:.bold.dim} {spinner} {wide_msg}")
             .unwrap()
             .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ ");
         let multi_progress = MultiProgress::new();
 
-        return packages
+        packages
             .iter()
             .map(|package| {
                 let package = package.clone();
@@ -71,75 +72,80 @@ impl RunScriptArgs {
                 progress_bar.set_prefix(format!("[{}]", package.name));
                 progress_bar.enable_steady_tick(Duration::from_millis(100));
 
-                return thread::spawn(move || {
-
-                    let reporter = ProgressBarReporter{
-                        progress_bar: &progress_bar
+                thread::spawn(move || {
+                    let reporter = ProgressBarReporter {
+                        progress_bar: &progress_bar,
                     };
-    
+
                     let result = exec_package(&package, &script_spec, &reporter).unwrap();
 
                     match result.result_type {
                         ScriptRunResultType::Success => {
-                            progress_bar.finish_with_message(format!("{}: {} ✨", result.command, style("Done").green()));
-                        },
+                            progress_bar.finish_with_message(format!(
+                                "{}: {} ✨",
+                                result.command,
+                                style("Done").green()
+                            ));
+                        }
                         ScriptRunResultType::Error(ref message) => {
-                            progress_bar.finish_with_message(format!("{}: {} ❌\n{}", result.command, style(message).red(), result.stderr));
-                        },
-                        ScriptRunResultType::Noop => progress_bar.finish_with_message(format!("Skipped! ⏭️"))
+                            progress_bar.finish_with_message(format!(
+                                "{}: {} ❌\n{}",
+                                result.command,
+                                style(message).red(),
+                                result.stderr
+                            ));
+                        }
+                        ScriptRunResultType::Noop => {
+                            progress_bar.finish_with_message("Skipped! ⏭️".to_string())
+                        }
                     }
 
-                    return PackageResult {
-                        package,
-                        result
-                    };
-                });
+                    PackageResult { package, result }
+                })
             })
             .collect::<Vec<_>>()
             .into_iter()
             .map(|h| h.join().unwrap())
-            .collect();
+            .collect()
     }
 
-    fn exec_non_interactive(&self, packages: &Vec<Package>) -> Vec<PackageResult<ScriptRunResult>> {
-
-        return packages
+    fn exec_non_interactive(&self, packages: &[Package]) -> Vec<PackageResult<ScriptRunResult>> {
+        packages
             .iter()
             .map(|package| {
                 let package = package.clone();
                 let script_spec = self.script_spec.clone();
 
-                return thread::spawn(move || {
-                
-                    let reporter = NoopProgressReporter{};
+                thread::spawn(move || {
+                    let reporter = NoopProgressReporter {};
 
                     let result = exec_package(&package, &script_spec, &reporter).unwrap();
 
-                    return PackageResult {
+                    PackageResult {
                         package: package.clone(),
-                        result
-                    };
-                });
+                        result,
+                    }
+                })
             })
             .collect::<Vec<_>>()
             .into_iter()
             .map(|h| h.join().unwrap())
-            .collect();
-
+            .collect()
     }
 }
 
 impl CommandExec<RunScriptResult> for RunScriptArgs {
-    fn exec(&self, context: &impl super::CommandExecutionContext) -> Box<dyn CommandResult<RunScriptResult>> {
+    fn exec(
+        &self,
+        context: &impl super::CommandExecutionContext,
+    ) -> Box<dyn CommandResult<RunScriptResult>> {
         let packages = context.get_project().get_packages(false);
-        
+
         let results = match context.get_cli().is_interactive() {
             true => self.exec_interactive(&packages),
-            false => self.exec_non_interactive(&packages)
+            false => self.exec_non_interactive(&packages),
         };
 
-        return Box::from(RunScriptResult{
-            results
-        });
+        Box::from(RunScriptResult { results })
     }
 }

--- a/src/bin/mrt/main.rs
+++ b/src/bin/mrt/main.rs
@@ -1,13 +1,14 @@
-use std::path::PathBuf;
-use clap::{Parser, Subcommand, CommandFactory, ValueHint};
+use clap::{CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{generate, Shell};
-use serde::ser;
-use commands::{list::ListArgs, run_script::RunScriptArgs, CommandExecutionContext, CommandExec};
-use output::write_command_stdout_as_json;
+use commands::{list::ListArgs, run_script::RunScriptArgs, CommandExec, CommandExecutionContext};
 use mrt::project::Project;
+use output::write_command_stdout_as_json;
+use serde::ser;
+use std::path::PathBuf;
 
 mod commands;
 mod output;
+#[cfg(test)]
 mod testing;
 
 /// MRT - MonoRepo Tool
@@ -28,7 +29,7 @@ pub struct Cli {
 
 #[derive(clap::ValueEnum, Clone)]
 enum Output {
-   Json
+    Json,
 }
 
 #[derive(Subcommand)]
@@ -40,18 +41,19 @@ pub enum Commands {
     /// outputs the completion file for given shell
     Completion {
         #[arg(index = 1, value_enum)]
-        shell: Shell
+        shell: Shell,
     },
 }
 
 impl Cli {
-    fn exec_command<T>(&self, executor: &impl CommandExec<T>) 
-        where T: ser::Serialize {
+    fn exec_command<T>(&self, executor: &impl CommandExec<T>)
+    where
+        T: ser::Serialize,
+    {
         let result = executor.exec(self);
 
-        match self.output {
-            Some(Output::Json) => write_command_stdout_as_json(&result),
-            _ => ()
+        if let Some(Output::Json) = self.output {
+            write_command_stdout_as_json(&*result)
         }
     }
 
@@ -62,12 +64,9 @@ impl Cli {
 
 impl CommandExecutionContext for Cli {
     fn get_project(&self) -> Project {
-        let manifest_path = self.manifest
-            .as_ref()
-            .and_then(|m| Some(PathBuf::from(m)));
-        
-        return Project::read(manifest_path)
-            .expect("Failed to read project manifest");
+        let manifest_path = self.manifest.as_ref().map(PathBuf::from);
+
+        Project::read(manifest_path).expect("Failed to read project manifest")
     }
 
     fn get_cli(&self) -> &Cli {
@@ -85,15 +84,14 @@ fn main() {
         Some(Commands::Run(args)) => {
             cli.exec_command(args);
         }
-        Some(Commands::Completion{ shell }) => {
+        Some(Commands::Completion { shell }) => {
             let mut cmd = Cli::command();
             let name = cmd.get_name().to_string();
-            generate(*shell, &mut cmd,name, &mut std::io::stdout());
+            generate(*shell, &mut cmd, name, &mut std::io::stdout());
         }
         None => {}
     }
 }
-
 
 #[test]
 fn verify_cli() {

--- a/src/bin/mrt/output.rs
+++ b/src/bin/mrt/output.rs
@@ -1,12 +1,14 @@
-use std::io::{stdout, Write};
 use serde::ser;
+use std::io::{stdout, Write};
 
 use crate::commands::CommandResult;
 
-pub(super) fn write_command_stdout_as_json<T>(result: &Box<dyn CommandResult<T>>)  
-    where T: ser::Serialize { 
-        let data = result.get_result();
-        let data_json = serde_json::to_string_pretty(&data).unwrap();
+pub(super) fn write_command_stdout_as_json<T>(result: &dyn CommandResult<T>)
+where
+    T: ser::Serialize,
+{
+    let data = result.get_result();
+    let data_json = serde_json::to_string_pretty(&data).unwrap();
 
-        stdout().write_all(data_json.as_bytes()).unwrap();
+    stdout().write_all(data_json.as_bytes()).unwrap();
 }

--- a/src/bin/mrt/testing.rs
+++ b/src/bin/mrt/testing.rs
@@ -1,62 +1,59 @@
-#[cfg(test)]
-pub mod testing {
+use crate::{
+    commands::{list::ListArgs, run_script::RunScriptArgs},
+    Cli,
+};
+use std::{env, path::PathBuf};
 
-    use std::{path::PathBuf, env};
-    use crate::{Cli, commands::{list::ListArgs, run_script::RunScriptArgs}};
-
-    fn get_repo_root() -> PathBuf {
-        let mut path = env::current_dir().unwrap();
-        while !path.join(".git").exists() {
-            path = path.parent().unwrap().to_path_buf();
-        }
-        path
+fn get_repo_root() -> PathBuf {
+    let mut path = env::current_dir().unwrap();
+    while !path.join(".git").exists() {
+        path = path.parent().unwrap().to_path_buf();
     }
+    path
+}
 
-    #[test]
-    fn test_list_basic_sample() -> anyhow::Result<()> {
-        let manifest = get_repo_root().join("./references/basic-sample/mrt.yml");
-        let cli = Cli{
-            command: None,
-            manifest: Some(manifest),
-            output: None
-        };
+#[test]
+fn test_list_basic_sample() -> anyhow::Result<()> {
+    let manifest = get_repo_root().join("./references/basic-sample/mrt.yml");
+    let cli = Cli {
+        command: None,
+        manifest: Some(manifest),
+        output: None,
+    };
 
-        cli.exec_command(&ListArgs{
-            all: false
-        });
+    cli.exec_command(&ListArgs { all: false });
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    #[test]
-    fn test_run_script_format_basic_sample() -> anyhow::Result<()> {
-        let manifest = get_repo_root().join("./references/basic-sample/mrt.yml");
-        let cli = Cli{
-            command: None,
-            manifest: Some(manifest),
-            output: None
-        };
+#[test]
+fn test_run_script_format_basic_sample() -> anyhow::Result<()> {
+    let manifest = get_repo_root().join("./references/basic-sample/mrt.yml");
+    let cli = Cli {
+        command: None,
+        manifest: Some(manifest),
+        output: None,
+    };
 
-        cli.exec_command(&RunScriptArgs{
-            script_spec: "format".to_string(),
-        });
+    cli.exec_command(&RunScriptArgs {
+        script_spec: "format".to_string(),
+    });
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    #[test]
-    fn test_run_script_build_basic_sample() -> anyhow::Result<()> {
-        let manifest = get_repo_root().join("./references/basic-sample/mrt.yml");
-        let cli = Cli{
-            command: None,
-            manifest: Some(manifest),
-            output: None
-        };
+#[test]
+fn test_run_script_build_basic_sample() -> anyhow::Result<()> {
+    let manifest = get_repo_root().join("./references/basic-sample/mrt.yml");
+    let cli = Cli {
+        command: None,
+        manifest: Some(manifest),
+        output: None,
+    };
 
-        cli.exec_command(&RunScriptArgs{
-            script_spec: "build".to_string(),
-        });
+    cli.exec_command(&RunScriptArgs {
+        script_spec: "build".to_string(),
+    });
 
-        Ok(())
-    }
+    Ok(())
 }

--- a/src/mrt/archetypes.rs
+++ b/src/mrt/archetypes.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use anyhow::Result;
+use std::path::Path;
 
 use crate::nodejs_npm::NodeJSNpmArchetype;
 use crate::python_poetry::PythonPoetryArchetype;
@@ -7,34 +7,29 @@ use crate::runners::ScriptRunner;
 
 pub trait Archetype {
     fn get_id(&self) -> &str;
-    fn matcher(&self, package_path: &PathBuf) -> bool;
+    fn matcher(&self, package_path: &Path) -> bool;
     fn get_script_runner(&self) -> Box<dyn ScriptRunner>;
-    fn get_info_extractor(&self, package_path: &PathBuf) -> Result<Box<dyn crate::package::PackageInfoExtractor>>;
+    fn get_info_extractor(
+        &self,
+        package_path: &Path,
+    ) -> Result<Box<dyn crate::package::PackageInfoExtractor>>;
 }
 
 fn get_archetypes() -> Vec<Box<dyn Archetype>> {
     vec![
         Box::new(NodeJSNpmArchetype {}),
-        Box::new(PythonPoetryArchetype {})
+        Box::new(PythonPoetryArchetype {}),
     ]
 }
 
-pub fn detect_archetype(package_path: &PathBuf) -> Option<Box<dyn Archetype>> {
-    let archetypes = get_archetypes();
-    for archetype in archetypes {
-        if archetype.matcher(package_path) {
-            return Some(archetype);
-        }
-    }
-    None
+pub fn detect_archetype(package_path: &Path) -> Option<Box<dyn Archetype>> {
+    get_archetypes()
+        .into_iter()
+        .find(|archetype| archetype.matcher(package_path))
 }
 
 pub fn get_archetype_by_id(id: &str) -> Option<Box<dyn Archetype>> {
-    let archetypes = get_archetypes();
-    for archetype in archetypes {
-        if archetype.get_id() == id {
-            return Some(archetype);
-        }
-    }
-    None
+    get_archetypes()
+        .into_iter()
+        .find(|archetype| archetype.get_id() == id)
 }

--- a/src/mrt/lib.rs
+++ b/src/mrt/lib.rs
@@ -1,9 +1,9 @@
-pub mod manifest;
 pub mod archetypes;
-pub mod package;
-pub mod project;
-pub mod runners;
-pub mod progress;
-mod testing;
+pub mod manifest;
 mod nodejs_npm;
+pub mod package;
+pub mod progress;
+pub mod project;
 mod python_poetry;
+pub mod runners;
+mod testing;

--- a/src/mrt/manifest.rs
+++ b/src/mrt/manifest.rs
@@ -1,16 +1,18 @@
-#[derive(Debug)]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Manifest {
-    pub packages: Vec<String>
+    pub packages: Vec<String>,
+}
+
+impl Default for Manifest {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Manifest {
     pub fn new() -> Manifest {
         Manifest {
-            packages: Vec::from([
-                String::from("./packages/*"),
-                String::from("./apps/*")
-            ])
+            packages: Vec::from([String::from("./packages/*"), String::from("./apps/*")]),
         }
     }
 }

--- a/src/mrt/nodejs_npm/info.rs
+++ b/src/mrt/nodejs_npm/info.rs
@@ -1,11 +1,11 @@
-use std::{path::PathBuf, fs::File, io::BufReader};
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use serde::Deserialize;
+use std::{fs::File, io::BufReader, path::Path};
 
-use crate::{package::PackageInfoExtractor};
+use crate::package::PackageInfoExtractor;
 
 pub struct NpmPackageInfoExtractor {
-    npm_package: NpmPackage
+    npm_package: NpmPackage,
 }
 
 // Structure represents package.json info
@@ -16,56 +16,67 @@ struct NpmPackage {
 }
 
 impl NpmPackageInfoExtractor {
-    pub fn from_package_path(package_path: &PathBuf) -> Result<NpmPackageInfoExtractor> {
-
+    pub fn from_package_path(package_path: &Path) -> Result<NpmPackageInfoExtractor> {
         let package_json_path = package_path.join("package.json");
 
-        let package_json_file = File::open(&package_json_path)
-            .with_context(|| format!("Failed to open package.json file at {}", package_json_path.display()))?;
+        let package_json_file = File::open(&package_json_path).with_context(|| {
+            format!(
+                "Failed to open package.json file at {}",
+                package_json_path.display()
+            )
+        })?;
         let package_json_reader = BufReader::new(package_json_file);
 
-        let package_json = serde_json::from_reader(package_json_reader)
-            .with_context(|| format!("Failed to parse JSON of package.json file at {}", package_json_path.display()))?;
+        let package_json = serde_json::from_reader(package_json_reader).with_context(|| {
+            format!(
+                "Failed to parse JSON of package.json file at {}",
+                package_json_path.display()
+            )
+        })?;
 
-        return Ok(NpmPackageInfoExtractor {
-            npm_package: package_json
-        });
+        Ok(NpmPackageInfoExtractor {
+            npm_package: package_json,
+        })
     }
 }
 
 impl PackageInfoExtractor for NpmPackageInfoExtractor {
     fn get_name(&self) -> &str {
-        return self.npm_package.name.as_str();
+        self.npm_package.name.as_str()
     }
 
     fn get_version(&self) -> &str {
-        return self.npm_package.version.as_str();
+        self.npm_package.version.as_str()
     }
 }
 
 #[test]
 fn test_from_package_path_no_folder_exists() {
-    let non_existing_package_path = PathBuf::from("does-not-exist");
-    
+    let non_existing_package_path = std::path::PathBuf::from("does-not-exist");
+
     let result = NpmPackageInfoExtractor::from_package_path(&non_existing_package_path);
-    
+
     assert!(result.is_err());
 }
 
 #[test]
 fn test_from_package_path_invalid_package_json() {
-    let invalid_package_json_lib_path = PathBuf::from(file!()).parent().unwrap().join("./fixures/invalid-package-json-lib");
-    
+    let invalid_package_json_lib_path = std::path::PathBuf::from(file!())
+        .parent()
+        .unwrap()
+        .join("./fixures/invalid-package-json-lib");
+
     let result = NpmPackageInfoExtractor::from_package_path(&invalid_package_json_lib_path);
-    
+
     assert!(result.is_err());
 }
 
 #[test]
 fn test_from_package_path_success() {
-    let lib1_path = crate::testing::utils::get_repo_root().join("./references/basic-sample/packages/node-lib1");
-    
+    let lib1_path =
+        crate::testing::utils::get_repo_root().join("./references/basic-sample/packages/node-lib1");
+
     let result = NpmPackageInfoExtractor::from_package_path(&lib1_path).unwrap();
-    
+
     assert_eq!(result.npm_package.name, "node-lib1");
 }

--- a/src/mrt/nodejs_npm/mod.rs
+++ b/src/mrt/nodejs_npm/mod.rs
@@ -1,13 +1,13 @@
-use std::path::PathBuf;
+use std::path::Path;
 
-use anyhow::{Result,Context};
+use anyhow::{Context, Result};
 
 use crate::{archetypes::Archetype, package::PackageInfoExtractor, runners::WrapperScriptRunner};
 
-use self::{runner::NpmPackageScriptRunner, info::NpmPackageInfoExtractor};
+use self::{info::NpmPackageInfoExtractor, runner::NpmPackageScriptRunner};
 
-mod runner;
 mod info;
+mod runner;
 
 pub struct NodeJSNpmArchetype {}
 
@@ -16,20 +16,23 @@ impl Archetype for NodeJSNpmArchetype {
         "nodejs/npm"
     }
 
-    fn matcher(&self, package_path: &PathBuf) -> bool {
+    fn matcher(&self, package_path: &Path) -> bool {
         package_path.join("package.json").exists()
     }
 
     fn get_script_runner(&self) -> Box<dyn crate::runners::ScriptRunner> {
-        Box::from(WrapperScriptRunner::wrap_with_generic_runners(
-            Box::from(NpmPackageScriptRunner::new())
-        ))
+        Box::from(WrapperScriptRunner::wrap_with_generic_runners(Box::from(
+            NpmPackageScriptRunner::new(),
+        )))
     }
 
-    fn get_info_extractor(&self, package_path: &PathBuf) -> Result<Box<dyn PackageInfoExtractor>> {
-        let extractor = NpmPackageInfoExtractor::from_package_path(package_path)
-            .context(format!("Get information extractor for package {}", package_path.display()))?;
+    fn get_info_extractor(&self, package_path: &Path) -> Result<Box<dyn PackageInfoExtractor>> {
+        let extractor =
+            NpmPackageInfoExtractor::from_package_path(package_path).context(format!(
+                "Get information extractor for package {}",
+                package_path.display()
+            ))?;
 
-        return Ok(Box::from(extractor));
+        Ok(Box::from(extractor))
     }
 }

--- a/src/mrt/nodejs_npm/runner.rs
+++ b/src/mrt/nodejs_npm/runner.rs
@@ -1,48 +1,37 @@
-use anyhow::{Result, Context};
-use crate::runners::{
-    ScriptRunner,
-    CommandRunner,
-    ScriptRunContext, 
-    ScriptRunResult
-};
+use crate::runners::{CommandRunner, ScriptRunContext, ScriptRunResult, ScriptRunner};
+use anyhow::{Context, Result};
 
 pub struct NpmPackageScriptRunner {
-    npm_runner: CommandRunner
+    npm_runner: CommandRunner,
 }
 
 impl NpmPackageScriptRunner {
     pub fn new() -> NpmPackageScriptRunner {
-        return NpmPackageScriptRunner {
-            npm_runner: CommandRunner::new("npm".to_string())
-        };
+        NpmPackageScriptRunner {
+            npm_runner: CommandRunner::new("npm".to_string()),
+        }
     }
 
     fn list_available_scripts(&self, context: &ScriptRunContext) -> Result<Vec<(String, String)>> {
-        
-        let json = self.npm_runner.exec_command_json(
-            vec!["run".to_string(), "--json".to_string()],
-            context
-        )?;
+        let json = self
+            .npm_runner
+            .exec_command_json(vec!["run".to_string(), "--json".to_string()], context)?;
 
         Ok(json
             .as_object()
             .context("`npm run --json` did not return an object")?
             .iter()
-            .map(|(key, value)| {
-                return (key.to_string(), value.to_string());
-            }).collect())
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect())
     }
 }
 
 impl ScriptRunner for NpmPackageScriptRunner {
     fn run_script(&self, context: &ScriptRunContext) -> Result<ScriptRunResult> {
-        return self.npm_runner.run_script(
-            vec![
-                "run".to_string(), 
-                context.script_spec.to_string()
-            ],
-            context
-        );
+        self.npm_runner.run_script(
+            vec!["run".to_string(), context.script_spec.to_string()],
+            context,
+        )
     }
 
     fn can_run_script(&self, context: &ScriptRunContext) -> Result<bool> {
@@ -50,8 +39,6 @@ impl ScriptRunner for NpmPackageScriptRunner {
 
         Ok(available_scripts
             .iter()
-            .any(|(key, _value)| {
-                return key == &context.script_spec;
-            }))
+            .any(|(key, _value)| key == context.script_spec))
     }
 }

--- a/src/mrt/package.rs
+++ b/src/mrt/package.rs
@@ -1,13 +1,14 @@
-use std::{path::PathBuf, fmt::{Formatter, Display}};
 use anyhow::Result;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::{Display, Formatter},
+    path::PathBuf,
+};
 use tabled::Tabled;
 
 use crate::archetypes::detect_archetype;
 
-#[derive(Clone, Debug)]
-#[derive(Serialize, Deserialize)]
-#[derive(Tabled)]
+#[derive(Clone, Debug, Serialize, Deserialize, Tabled)]
 pub struct Package {
     pub name: String,
     pub version: String,
@@ -18,12 +19,11 @@ pub struct Package {
     pub status: PackageStatus,
 }
 
-#[derive(Clone, Debug)]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PackageStatus {
     Valid,
     CannotRead(String),
-    CannotDetectArchetype
+    CannotDetectArchetype,
 }
 
 impl Display for PackageStatus {
@@ -31,7 +31,7 @@ impl Display for PackageStatus {
         match self {
             PackageStatus::Valid => write!(f, "Valid"),
             PackageStatus::CannotRead(message) => write!(f, "Error: {}", message),
-            PackageStatus::CannotDetectArchetype => write!(f, "Cannot detect archetype")
+            PackageStatus::CannotDetectArchetype => write!(f, "Cannot detect archetype"),
         }
     }
 }
@@ -39,50 +39,47 @@ impl Display for PackageStatus {
 impl Package {
     pub fn from_package_path(package_path: PathBuf, project_path: PathBuf) -> Result<Package> {
         let absolute_path = package_path.canonicalize()?;
-        
+
         let path = absolute_path
-                .strip_prefix(&project_path)?
-                .to_str().unwrap_or("n/a").to_string();
+            .strip_prefix(&project_path)?
+            .to_str()
+            .unwrap_or("n/a")
+            .to_string();
 
         match detect_archetype(&absolute_path) {
             Some(archetype) => {
                 match archetype.get_info_extractor(&absolute_path) {
-                    Ok(extractor) => {
-                        return Ok(Package {
-                            name: extractor.get_name().to_string(),
-                            version: extractor.get_version().to_string(),
-                            path,
-                            absolute_path,
-                            archetype_id: archetype.get_id().to_string(),
-                            status: PackageStatus::Valid
-                        })
-                    },
+                    Ok(extractor) => Ok(Package {
+                        name: extractor.get_name().to_string(),
+                        version: extractor.get_version().to_string(),
+                        path,
+                        absolute_path,
+                        archetype_id: archetype.get_id().to_string(),
+                        status: PackageStatus::Valid,
+                    }),
                     Err(err) => {
                         // Archetype detected, but cannot read package info
-                        return Ok(Package {
+                        Ok(Package {
                             name: String::from("n/a"),
                             version: String::from("n/a"),
                             path,
                             absolute_path,
                             archetype_id: archetype.get_id().to_string(),
-                            status: PackageStatus::CannotRead(err.to_string())
+                            status: PackageStatus::CannotRead(err.to_string()),
                         })
-                    },
+                    }
                 }
-            },
-            None => {
-                return Ok(Package {
-                    name: String::from("n/a"),
-                    version:  String::from("n/a"),
-                    path,
-                    absolute_path,
-                    archetype_id: String::default(),
-                    status: PackageStatus::CannotDetectArchetype
-                })
             }
+            None => Ok(Package {
+                name: String::from("n/a"),
+                version: String::from("n/a"),
+                path,
+                absolute_path,
+                archetype_id: String::default(),
+                status: PackageStatus::CannotDetectArchetype,
+            }),
         }
     }
-    
 }
 
 pub trait PackageInfoExtractor {
@@ -94,10 +91,10 @@ pub struct NoopPackageInfoExtractor {}
 
 impl PackageInfoExtractor for NoopPackageInfoExtractor {
     fn get_name(&self) -> &str {
-        return "noop";
+        "noop"
     }
 
     fn get_version(&self) -> &str {
-        return "noop";
+        "noop"
     }
 }

--- a/src/mrt/progress.rs
+++ b/src/mrt/progress.rs
@@ -1,7 +1,6 @@
 use log::info;
 
-pub struct LogProgressReporter {
-}
+pub struct LogProgressReporter {}
 
 impl ProgressReporter for LogProgressReporter {
     fn report_output(&self, message: &str) {

--- a/src/mrt/project.rs
+++ b/src/mrt/project.rs
@@ -1,10 +1,10 @@
-use std::path::PathBuf;
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use glob::glob;
 use log::warn;
+use std::path::PathBuf;
 
-use crate::package::{Package, PackageStatus};
 use crate::manifest::Manifest;
+use crate::package::{Package, PackageStatus};
 
 #[derive(Debug)]
 pub struct Project {
@@ -13,51 +13,52 @@ pub struct Project {
 }
 
 impl Project {
-
     /// Read project from manifest path if defined. if not will use current directory and mrt.yml file
     pub fn read(manifest_path: Option<PathBuf>) -> Result<Project> {
-
         let root_path = match manifest_path {
             Some(path) => {
-                // Here means user specified manifest path 
+                // Here means user specified manifest path
                 // and we assume he knows what he is doing
                 let manifest_path = path.canonicalize()?;
 
-                manifest_path.parent()
-                    .with_context(|| format!("Manifest path {:?} has no parent, cannot determine project root", manifest_path))?
+                manifest_path
+                    .parent()
+                    .with_context(|| {
+                        format!(
+                            "Manifest path {:?} has no parent, cannot determine project root",
+                            manifest_path
+                        )
+                    })?
                     .canonicalize()?
-            },
-            None => std::env::current_dir()?
+            }
+            None => std::env::current_dir()?,
         };
 
         Ok(Project {
             root_path,
-            manifest: Manifest::new()
+            manifest: Manifest::new(),
         })
     }
-    
+
     pub fn get_root_path(&self) -> &PathBuf {
         &self.root_path
     }
 
     pub fn read_package(&self, package_path: PathBuf) -> Result<Package> {
-        return Package::from_package_path(
-            self.root_path.join(package_path),
-            self.root_path.clone()
-        );
+        Package::from_package_path(self.root_path.join(package_path), self.root_path.clone())
     }
 
     pub fn get_packages(&self, all: bool) -> Vec<Package> {
-
         let mut packages: Vec<Package> = vec![];
 
         for package_glob in &self.manifest.packages {
-            let rooted_package_glob = self.root_path.join(&package_glob);
+            let rooted_package_glob = self.root_path.join(package_glob);
 
-            let full_glob = rooted_package_glob.to_str()
-                .expect(&format!("Convert path `{}` to string", rooted_package_glob.display()));
+            let full_glob = rooted_package_glob.to_str().unwrap_or_else(|| {
+                panic!("Convert path `{}` to string", rooted_package_glob.display())
+            });
 
-            match glob(&full_glob) {
+            match glob(full_glob) {
                 Ok(paths) => {
                     paths
                         .filter_map(Result::ok)
@@ -68,24 +69,30 @@ impl Project {
                             match package.status {
                                 PackageStatus::Valid => {
                                     packages.push(package);
-                                },
+                                }
                                 PackageStatus::CannotRead(ref message) => {
                                     if all {
                                         packages.push(package);
                                     } else {
-                                        warn!("Cannot read package at path '{}': {}", package.path, message);
+                                        warn!(
+                                            "Cannot read package at path '{}': {}",
+                                            package.path, message
+                                        );
                                     }
-                                },
+                                }
                                 PackageStatus::CannotDetectArchetype => {
                                     if all {
                                         packages.push(package);
                                     } else {
-                                        warn!("Cannot detect package archetype at path '{}'", package.path);
+                                        warn!(
+                                            "Cannot detect package archetype at path '{}'",
+                                            package.path
+                                        );
                                     }
                                 }
                             }
                         });
-                },
+                }
                 Err(err) => {
                     warn!("Package glob {} failed: {}. Ignoring.", &full_glob, err);
                     continue;

--- a/src/mrt/python_poetry/info.rs
+++ b/src/mrt/python_poetry/info.rs
@@ -1,66 +1,69 @@
-use std::{path::PathBuf};
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use serde::Deserialize;
-use toml;
+use std::path::Path;
 
-use crate::{package::PackageInfoExtractor};
+use crate::package::PackageInfoExtractor;
 
 pub struct PoetryPackageInfoExtractor {
-    poetry_pyproject: PoetryPyProject
+    poetry_pyproject: PoetryPyProject,
 }
 
 #[derive(Deserialize, Debug)]
 struct PyProjectToolPoetry {
     name: String,
-    version: String
+    version: String,
 }
 
 #[derive(Deserialize, Debug)]
 struct PyProjectTool {
-    poetry: PyProjectToolPoetry
+    poetry: PyProjectToolPoetry,
 }
 
 // Represents Poetry package info from pyproject.toml
 #[derive(Deserialize, Debug)]
 struct PoetryPyProject {
-    tool: PyProjectTool
+    tool: PyProjectTool,
 }
 
 impl PoetryPackageInfoExtractor {
-
-    pub fn from_package_path(package_path: &PathBuf) -> Result<PoetryPackageInfoExtractor> {
-
+    pub fn from_package_path(package_path: &Path) -> Result<PoetryPackageInfoExtractor> {
         let pyproject_toml_path = package_path.join("pyproject.toml");
 
-        let pyproject_toml_content = std::fs::read_to_string(&pyproject_toml_path)
-            .with_context(|| format!("Failed to read pyproject.toml file at {}", pyproject_toml_path.display()))?;
+        let pyproject_toml_content =
+            std::fs::read_to_string(&pyproject_toml_path).with_context(|| {
+                format!(
+                    "Failed to read pyproject.toml file at {}",
+                    pyproject_toml_path.display()
+                )
+            })?;
 
-        return Ok(PoetryPackageInfoExtractor {
-            poetry_pyproject:  toml::from_str(&pyproject_toml_content)?
-        });
+        Ok(PoetryPackageInfoExtractor {
+            poetry_pyproject: toml::from_str(&pyproject_toml_content)?,
+        })
     }
 }
 
 impl PackageInfoExtractor for PoetryPackageInfoExtractor {
     fn get_name(&self) -> &str {
-        return self.poetry_pyproject.tool.poetry.name.as_str();
+        self.poetry_pyproject.tool.poetry.name.as_str()
     }
 
     fn get_version(&self) -> &str {
-        return self.poetry_pyproject.tool.poetry.version.as_str();
+        self.poetry_pyproject.tool.poetry.version.as_str()
     }
 }
 
 #[test]
 fn test_from_package_path_no_folder_exists() {
-    let non_existing_package_path = PathBuf::from("does-not-exist");
+    let non_existing_package_path = std::path::PathBuf::from("does-not-exist");
     let result = PoetryPackageInfoExtractor::from_package_path(&non_existing_package_path);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_from_package_path_success() {
-    let lib1_path = crate::testing::utils::get_repo_root().join("./references/basic-sample/packages/py-lib2");
+    let lib1_path =
+        crate::testing::utils::get_repo_root().join("./references/basic-sample/packages/py-lib2");
     let result = PoetryPackageInfoExtractor::from_package_path(&lib1_path).unwrap();
     assert_eq!(result.get_name(), "py_lib2");
 }

--- a/src/mrt/python_poetry/mod.rs
+++ b/src/mrt/python_poetry/mod.rs
@@ -1,12 +1,8 @@
-use std::{path::PathBuf, fs};
+use std::{fs, path::Path};
 
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 
-use crate::{
-    archetypes::Archetype, 
-    runners::WrapperScriptRunner, 
-    package::PackageInfoExtractor
-};
+use crate::{archetypes::Archetype, package::PackageInfoExtractor, runners::WrapperScriptRunner};
 
 use self::info::PoetryPackageInfoExtractor;
 
@@ -19,7 +15,7 @@ impl Archetype for PythonPoetryArchetype {
         "python/poetry"
     }
 
-    fn matcher(&self, path: &PathBuf) -> bool {
+    fn matcher(&self, path: &Path) -> bool {
         let pyproject = path.join("pyproject.toml");
 
         if pyproject.exists() {
@@ -27,43 +23,50 @@ impl Archetype for PythonPoetryArchetype {
 
             return contents.contains("[tool.poetry]");
         }
-        return false;
+        false
     }
 
     fn get_script_runner(&self) -> Box<dyn crate::runners::ScriptRunner> {
         Box::from(WrapperScriptRunner::generic_runners())
     }
 
-    fn get_info_extractor(&self, package_path: &PathBuf) -> Result<Box<dyn PackageInfoExtractor>> {
-        let extractor = PoetryPackageInfoExtractor::from_package_path(package_path)
-            .context(format!("Get information extractor for package {}", package_path.display()))?;
+    fn get_info_extractor(&self, package_path: &Path) -> Result<Box<dyn PackageInfoExtractor>> {
+        let extractor =
+            PoetryPackageInfoExtractor::from_package_path(package_path).context(format!(
+                "Get information extractor for package {}",
+                package_path.display()
+            ))?;
 
-        return Ok(Box::from(extractor));
+        Ok(Box::from(extractor))
     }
 }
 
-
 #[test]
 fn test_script_runner_make() -> anyhow::Result<()> {
-    let project_path = crate::testing::utils::get_repo_root().join("./references/basic-sample/mrt.yml");
+    let project_path =
+        crate::testing::utils::get_repo_root().join("./references/basic-sample/mrt.yml");
     let project = crate::project::Project::read(Some(project_path))?;
     let package = project.read_package(std::path::PathBuf::from("./packages/py-lib2"))?;
 
-    let archetype = PythonPoetryArchetype{};
+    let archetype = PythonPoetryArchetype {};
 
     let runner = archetype.get_script_runner();
 
     let context = crate::runners::ScriptRunContext {
         script_spec: "format",
         package: &package,
-        reporter: &crate::progress::LogProgressReporter{}
+        reporter: &crate::progress::LogProgressReporter {},
     };
 
     assert!(runner.can_run_script(&context)?);
 
     let result = runner.run_script(&context)?;
 
-    assert!(result.result_type.is_success(), "stderr: {:?}", result.stderr);
+    assert!(
+        result.result_type.is_success(),
+        "stderr: {:?}",
+        result.stderr
+    );
 
     Ok(())
 }

--- a/src/mrt/runners.rs
+++ b/src/mrt/runners.rs
@@ -1,7 +1,10 @@
-use std::{io::{BufReader, BufRead}, process::{Stdio, Command}};
-use anyhow::{Result, Context};
-use serde::{Serialize, Deserialize};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::{
+    io::{BufRead, BufReader},
+    process::{Command, Stdio},
+};
 
 use crate::progress::ProgressReporter;
 
@@ -10,29 +13,23 @@ use super::package::Package;
 pub struct ScriptRunContext<'a> {
     pub script_spec: &'a str,
     pub package: &'a Package,
-    pub reporter: &'a dyn ProgressReporter
+    pub reporter: &'a dyn ProgressReporter,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ScriptRunResultType {
     Success,
     Error(String),
-    Noop
+    Noop,
 }
 
 impl ScriptRunResultType {
     pub fn is_success(&self) -> bool {
-        match self {
-            ScriptRunResultType::Success => true,
-            _ => false
-        }
+        matches!(self, ScriptRunResultType::Success)
     }
 
     pub fn is_noop(&self) -> bool {
-        match self {
-            ScriptRunResultType::Noop => true,
-            _ => false
-        }
+        matches!(self, ScriptRunResultType::Noop)
     }
 }
 
@@ -42,9 +39,8 @@ pub struct ScriptRunResult {
     pub result_type: ScriptRunResultType,
     pub exit_code: i32,
     pub stdout: String,
-    pub stderr: String
+    pub stderr: String,
 }
-
 
 pub trait ScriptRunner {
     fn can_run_script(&self, context: &ScriptRunContext) -> Result<bool>;
@@ -53,19 +49,17 @@ pub trait ScriptRunner {
 
 impl ScriptRunResult {
     pub fn noop() -> ScriptRunResult {
-        return ScriptRunResult {
+        ScriptRunResult {
             command: String::default(),
             result_type: ScriptRunResultType::Noop,
             exit_code: 0,
             stdout: String::from(""),
-            stderr: String::from("")
-        };
+            stderr: String::from(""),
+        }
     }
 }
 
-
-pub struct NoopScriptRunner {
-}
+pub struct NoopScriptRunner {}
 
 impl ScriptRunner for NoopScriptRunner {
     fn can_run_script(&self, _context: &ScriptRunContext) -> Result<bool> {
@@ -77,32 +71,34 @@ impl ScriptRunner for NoopScriptRunner {
     }
 }
 
-pub (crate) struct CommandRunner{
-    program: String
+pub(crate) struct CommandRunner {
+    program: String,
 }
 
 impl CommandRunner {
     pub fn new(program: String) -> Self {
-        return Self {
-            program
-        };
+        Self { program }
     }
 
-    pub fn can_run_script_dry_run(&self, dry_run_args: Vec<String>, context: &ScriptRunContext) -> Result<bool> {
+    pub fn can_run_script_dry_run(
+        &self,
+        dry_run_args: Vec<String>,
+        context: &ScriptRunContext,
+    ) -> Result<bool> {
         let context_path = &context.package.absolute_path;
         let output = Command::new(&self.program)
             .args(dry_run_args)
             .current_dir(context_path)
             .output()?;
 
-        return Ok(match output.status.code() {
-            Some(0) => true,
-            _ => false
-        });
+        Ok(matches!(output.status.code(), Some(0)))
     }
 
-    pub fn exec_command_json(&self, args: Vec<String>, context: &ScriptRunContext) -> Result<Value> {
-
+    pub fn exec_command_json(
+        &self,
+        args: Vec<String>,
+        context: &ScriptRunContext,
+    ) -> Result<Value> {
         let context_path = &context.package.absolute_path;
         let output = Command::new(&self.program)
             .args(args)
@@ -118,13 +114,15 @@ impl CommandRunner {
         Ok(json)
     }
 
-    pub fn run_script(&self, run_script_args: Vec<String>, context: &ScriptRunContext) -> Result<ScriptRunResult> {
-        let command_desc =format!("{} {}", 
-            self.program, 
-            run_script_args.join(" "));
-    
+    pub fn run_script(
+        &self,
+        run_script_args: Vec<String>,
+        context: &ScriptRunContext,
+    ) -> Result<ScriptRunResult> {
+        let command_desc = format!("{} {}", self.program, run_script_args.join(" "));
+
         context.reporter.report_output(&command_desc);
-        
+
         let context_path = &context.package.absolute_path;
         let mut child = Command::new(&self.program)
             .args(run_script_args)
@@ -132,97 +130,93 @@ impl CommandRunner {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()?;
-    
-    
-        let stdout = child.stdout.take()
-            .with_context(|| format!("Failed to capture standard output for command {}", command_desc))?;
-            
+
+        let stdout = child.stdout.take().with_context(|| {
+            format!(
+                "Failed to capture standard output for command {}",
+                command_desc
+            )
+        })?;
+
         let reader = BufReader::new(stdout);
-        
+
         let mut stdout_lines = String::default();
 
-        reader
-            .lines()
-            .filter_map(|line| line.ok())
-            .for_each(|line| {
-                if line.len() > 0 {
-                    context.reporter.report_output(&format!("{}: {}", command_desc, line));
-                }
-                stdout_lines.push_str(&line);
-            });
+        reader.lines().map_while(Result::ok).for_each(|line| {
+            if !line.is_empty() {
+                context
+                    .reporter
+                    .report_output(&format!("{}: {}", command_desc, line));
+            }
+            stdout_lines.push_str(&line);
+        });
 
         let output = child.wait_with_output()?;
 
         let result_type = match output.status.code() {
             Some(0) => ScriptRunResultType::Success,
             Some(exit_code) => ScriptRunResultType::Error(format!("Exit code {exit_code}")),
-            None => ScriptRunResultType::Noop
+            None => ScriptRunResultType::Noop,
         };
- 
+
         Ok(ScriptRunResult {
             command: command_desc,
             result_type,
             exit_code: output.status.code().unwrap_or_default(),
             stdout: stdout_lines,
-            stderr: String::from_utf8(output.stderr).unwrap_or_default()
+            stderr: String::from_utf8(output.stderr).unwrap_or_default(),
         })
     }
 }
 
-
 pub struct MakeScriptRunner {
-    make_runner: CommandRunner
+    make_runner: CommandRunner,
+}
+
+impl Default for MakeScriptRunner {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MakeScriptRunner {
     pub fn new() -> Self {
-        return Self {
-            make_runner: CommandRunner::new("make".to_string())
-        };
+        Self {
+            make_runner: CommandRunner::new("make".to_string()),
+        }
     }
 }
 
-
 impl ScriptRunner for MakeScriptRunner {
     fn run_script(&self, context: &ScriptRunContext) -> Result<ScriptRunResult> {
-        return self.make_runner.run_script(
-            vec![context.script_spec.to_string()],
-            context
-        );
+        self.make_runner
+            .run_script(vec![context.script_spec.to_string()], context)
     }
 
     fn can_run_script(&self, context: &ScriptRunContext) -> Result<bool> {
-        return self.make_runner.can_run_script_dry_run(
-            vec![
-                context.script_spec.to_string(), 
-                "--dry-run".to_string()
-            ],
-            context
-        );
+        self.make_runner.can_run_script_dry_run(
+            vec![context.script_spec.to_string(), "--dry-run".to_string()],
+            context,
+        )
     }
 }
 
 pub struct WrapperScriptRunner {
-    runners: Vec<Box<dyn ScriptRunner>>
+    runners: Vec<Box<dyn ScriptRunner>>,
 }
 
 impl WrapperScriptRunner {
     pub fn wrap_with_generic_runners(runner: Box<dyn ScriptRunner>) -> Self {
         // Runners should be from generic to specific
         // So for example `make` is considered to be more generic
-        return Self {
-            runners: vec![
-                Box::new(MakeScriptRunner::new()),
-                runner
-            ]
+        Self {
+            runners: vec![Box::new(MakeScriptRunner::new()), runner],
         }
     }
 
     pub fn generic_runners() -> Self {
-        return Self {
-            runners: vec![
-                Box::new(MakeScriptRunner::new())
-            ]
+        Self {
+            runners: vec![Box::new(MakeScriptRunner::new())],
         }
     }
 }
@@ -235,7 +229,7 @@ impl ScriptRunner for WrapperScriptRunner {
             }
         }
 
-        return Ok(false);
+        Ok(false)
     }
 
     fn run_script(&self, context: &ScriptRunContext) -> Result<ScriptRunResult> {
@@ -245,41 +239,47 @@ impl ScriptRunner for WrapperScriptRunner {
             }
         }
 
-        return Ok(ScriptRunResult::noop())
+        Ok(ScriptRunResult::noop())
     }
 }
 
 #[test]
 fn test_make_script_runner() -> anyhow::Result<()> {
-    let project_path = crate::testing::utils::get_repo_root().join("./references/basic-sample/mrt.yml");
+    let project_path =
+        crate::testing::utils::get_repo_root().join("./references/basic-sample/mrt.yml");
     let project = crate::project::Project::read(Some(project_path))?;
     let package = project.read_package(std::path::PathBuf::from("./packages/make-lib5"))?;
     let runner = MakeScriptRunner::new();
     let context = ScriptRunContext {
         script_spec: "format",
         package: &package,
-        reporter: &crate::progress::LogProgressReporter{}
+        reporter: &crate::progress::LogProgressReporter {},
     };
 
     assert!(runner.can_run_script(&context)?);
 
     let result = runner.run_script(&context)?;
 
-    assert!(result.result_type.is_success(), "stderr: {:?}", result.stderr);
+    assert!(
+        result.result_type.is_success(),
+        "stderr: {:?}",
+        result.stderr
+    );
 
     Ok(())
 }
 
 #[test]
 fn test_make_script_runner_run_no_script() -> anyhow::Result<()> {
-    let project_path = crate::testing::utils::get_repo_root().join("./references/basic-sample/mrt.yml");
+    let project_path =
+        crate::testing::utils::get_repo_root().join("./references/basic-sample/mrt.yml");
     let project = crate::project::Project::read(Some(project_path))?;
     let package = project.read_package(std::path::PathBuf::from("./packages/make-lib5"))?;
     let runner = MakeScriptRunner::new();
     let context = ScriptRunContext {
         script_spec: "no-such-script",
         package: &package,
-        reporter: &crate::progress::LogProgressReporter{}
+        reporter: &crate::progress::LogProgressReporter {},
     };
     assert!(!runner.can_run_script(&context)?);
 

--- a/src/mrt/testing.rs
+++ b/src/mrt/testing.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 pub mod utils {
-    use std::{path::PathBuf, env};
+    use std::{env, path::PathBuf};
 
     pub fn get_repo_root() -> PathBuf {
         let mut path = env::current_dir().unwrap();


### PR DESCRIPTION
## What
Modernize the existing Rust source to pass current rustfmt and clippy, and make the sample Poetry package test hermetic.

## Why
The repository did not pass formatting or clippy on a current toolchain, and one test failed unless Poetry happened to be installed. A green baseline keeps later dependency and CI upgrades focused.

## How
- Apply current rustfmt and clippy improvements
- Prefer borrowed paths and slices in public/internal APIs
- Remove the redundant nested test module
- Replace the Poetry-dependent fixture command with a portable shell command

## Risk
- Low
- Mechanical source cleanup with no intended CLI behavior change

## Security
No security-relevant code changes.

## Follow-ups
Dependency, CI, and release modernization will follow in separate PRs.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed