### PR TITLE
chore(project): modernize release and contributor setup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## What changed
+
+Describe the user- or developer-visible outcome.
+
+## Why
+
+Explain the problem or motivation.
+
+## Before / after
+
+Show observable evidence when behavior changes. For internal-only changes, say
+that there is no user-visible difference.
+
+## Risk
+
+- Low / Medium / High
+- What can break
+
+## Validation
+
+List the checks and smoke tests performed.
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Backward compatibility considered
+- [ ] Security impact reviewed
+- [ ] Documentation updated when needed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust build
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,144 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    name: Validate tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag and package version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          PACKAGE_VERSION=$(cargo metadata --locked --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "mrt") | .version')
+          if [ -z "$PACKAGE_VERSION" ]; then
+            echo "::error::Could not read the MRT package version"
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = push ]; then
+            if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Release tag must match vMAJOR.MINOR.PATCH"
+              exit 1
+            fi
+            if [ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]; then
+              echo "::error::Tag $RELEASE_TAG does not match Cargo.toml version $PACKAGE_VERSION"
+              exit 1
+            fi
+
+            git fetch --force origin main:refs/remotes/origin/main
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+              echo "::error::Release tag must point to a commit reachable from main"
+              exit 1
+            fi
+          fi
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: mrt-x86_64-unknown-linux-gnu.tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            archive: mrt-aarch64-apple-darwin.tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-14
+            archive: mrt-x86_64-apple-darwin.tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            archive: mrt-x86_64-pc-windows-msvc.zip
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          shared-key: release-${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Package Unix binary
+        if: runner.os != 'Windows'
+        env:
+          ARCHIVE: ${{ matrix.archive }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          tar -C "target/$TARGET/release" -czf "$ARCHIVE" mrt
+          shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+
+      - name: Package Windows binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          ARCHIVE: ${{ matrix.archive }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          Compress-Archive -Path "target/$env:TARGET/release/mrt.exe" -DestinationPath $env:ARCHIVE
+          $hash = (Get-FileHash $env:ARCHIVE -Algorithm SHA256).Hash.ToLower()
+          "$hash  $env:ARCHIVE" | Out-File -Encoding ascii "$env:ARCHIVE.sha256"
+
+      - name: Upload release asset
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-${{ matrix.target }}
+          path: |
+            ${{ matrix.archive }}
+            ${{ matrix.archive }}.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@c12583777ecdfd3be55c69cf75464299dc01057e # v3
+        with:
+          name: MRT ${{ github.ref_name }}
+          generate_release_notes: true
+          files: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to MRT are documented in this file. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and releases use
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Upgraded to Rust 1.97.0 and edition 2024.
+- Updated all direct and transitive dependencies.
+- Modernized formatting, linting, tests, and cross-platform CI.
+
+### Security
+
+- Added RustSec advisory scanning and dependency license/source policy checks.
+- Pinned GitHub Actions to immutable revisions with read-only permissions.
+
+[Unreleased]: https://github.com/chaliy/mrt/compare/v1.0.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to MRT
+
+## Setup
+
+Install Git and Rust. The repository's `rust-toolchain.toml` installs the
+supported compiler, formatter, and linter automatically.
+
+```console
+git clone https://github.com/chaliy/mrt.git
+cd mrt
+cargo build --locked
+```
+
+## Development workflow
+
+Create a branch from current `main` and keep each change focused. Add tests for
+new behavior and update the README when user-facing behavior changes.
+
+Before opening a pull request, run:
+
+```console
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-features
+cargo doc --locked --no-deps --all-features
+cargo deny check
+cargo audit
+```
+
+Commit and pull-request titles use Conventional Commits, for example:
+
+```text
+feat(cli): filter packages by path
+fix(runner): preserve command output newlines
+docs: clarify manifest discovery
+```
+
+Pull requests should explain the outcome, motivation, risk, and validation.
+CI must pass before a change is merged.
+
+## Releases
+
+1. Update the version in `Cargo.toml` and refresh `Cargo.lock`.
+2. Move the relevant entries from `Unreleased` into a versioned changelog
+   section such as `## [1.1.0] - 2026-07-16`.
+3. Merge the release preparation pull request.
+4. Create and push an annotated `vMAJOR.MINOR.PATCH` tag from `main`.
+
+The release workflow verifies that the tag matches `Cargo.toml`, builds
+precompiled binaries, generates checksums, and publishes a GitHub Release.
+The `mrt` package name is already owned by an unrelated crate on crates.io, so
+MRT is distributed through GitHub rather than crates.io.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the MIT
+License.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@ name = "mrt"
 version = "1.0.0"
 edition = "2024"
 license = "MIT"
+authors = ["Mykhailo Chalyi <mike@chaliy.name>"]
+description = "A task runner for polyglot monorepos"
+repository = "https://github.com/chaliy/mrt"
+homepage = "https://github.com/chaliy/mrt"
+readme = "README.md"
+keywords = ["monorepo", "task-runner", "cli", "polyglot"]
+categories = ["command-line-utilities", "development-tools::build-utils"]
 
 [lib]
 name = "mrt"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mykhailo Chalyi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,66 +1,76 @@
-# MRT - MonoRepo Tool
+# MRT — Monorepo Tool
 
-cli to serve polyglot monorepo
+MRT discovers packages in a polyglot monorepo and runs the same script across
+them. It currently understands npm and Poetry package metadata and can execute
+npm scripts or Make targets.
 
-## Features
+## Install
 
-- [x] List package in the monorepo - `mrt list`
-- [x] Ability to execute "scripts" across monorepo: start, build, test, format, etc - `mrt run [script]`
-- [x] Support for nodejs/npm packages and apps
-- [ ] Support for python/poetry packages and apps
-- [ ] Support for rust/cargo packages and apps
-- [ ] Support for custom packages and apps
-- [x] Support for Makefile as extra scripts to run
-- ...
+Install the latest development version with Cargo:
 
-## How to install
-
-If you have rust/cargo installed, you can install `mrt` with:
-
-```
-cargo install --git https://github.com/chaliy/mrt.git
-mrt --help
+```console
+cargo install --git https://github.com/chaliy/mrt.git --locked
 ```
 
-### ZSH
+Versioned releases also provide prebuilt binaries for Linux, macOS, and Windows
+on the [GitHub Releases](https://github.com/chaliy/mrt/releases) page.
 
+## Use
+
+MRT looks for packages under `packages/*` and `apps/*`. Pass a manifest path to
+set the monorepo root:
+
+```console
+mrt --manifest ./mrt.yml list
+mrt --manifest ./mrt.yml list --all
+mrt --manifest ./mrt.yml run build
+mrt --manifest ./mrt.yml --output json list
 ```
-mrt completion zsh > $ZSH/cache/completions/_mrt
-compinit
-mrt <TAB>
+
+Without `--manifest`, MRT uses the current directory as the project root.
+`list --all` includes directories whose package metadata could not be read or
+whose package type could not be detected.
+
+### Shell completion
+
+Generate completion scripts for Bash, Elvish, Fish, PowerShell, or Zsh:
+
+```console
+mrt completion zsh > _mrt
 ```
 
-## Idea
+## Supported packages
 
-Build tool that will help with common operations on polyglot monorepo. Run "scripts" across all packages, do release management, etc. 
+| Package type | Detection | Script runner |
+| --- | --- | --- |
+| npm | `package.json` | `make <script>`, then `npm run <script>` |
+| Poetry | `pyproject.toml` with `[tool.poetry]` | `make <script>` |
 
-- Run "scripts" across monorepo like build, test, fmt, etc - `mrt run [script]`
-- Polyglot packages, mrt should run any. Initially nodejs/npm, python/poetry, Makefile and custom
-- Dependency graph, if packages depends on each other, mrt should know
-- Be aware of changes, detect changes and run scripts against changes
-- Allow filter / group / list packages. So for example need to find a way to run "test" script only on "ui" packages
+When both a Make target and a package-manager script exist, MRT uses the Make
+target first.
 
-### More?
+## Develop
 
-- Help with CI, for example command to proxy package command only when something has been changed
-- Handle initialization of dev environment
-- Handle running monorepo (e.g. microservices docker-compose)
-- Version / release management. Single repo version, or per package version
+The repository pins its Rust toolchain. Run the same core checks as CI with:
 
-## Design
+```console
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-features
+cargo deny check
+cargo audit
+```
 
-### CLI
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the complete workflow.
 
-`mrt list` - List all monorepo packages
-`mrt list [packages_spec]` - List specified packages
+## Roadmap
 
-`mrt run [packages_spec] [script]` - Run script for specified packages
-`mrt run [script]` - Run script for all specified packages
+- Read package globs and configuration from the manifest
+- Add native Cargo package support
+- Filter packages by name, path, type, or changed files
+- Model package dependencies and execution order
+- Coordinate versioning and releases across packages
 
+## License
 
-`[packages_spec]` - package | package1,package2 | pa* | packages/pack* 
-
-## Inspiration
-
-- Lerna / Nx - NodeJS monorepo tools
-- Bazel - monorepo build tool
+MRT is available under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability. Send a private report
+to `mike@chaliy.name` with a description, reproduction steps, potential impact,
+and any suggested remediation.
+
+You should receive an acknowledgment within 72 hours and an initial assessment
+within seven days.
+
+## Supported versions
+
+Security fixes are provided for the latest released version of MRT.
+
+## Scope
+
+Reports about command execution, package discovery crossing the configured
+project boundary, unsafe handling of package metadata, release artifacts, and
+the dependency supply chain are in scope.


### PR DESCRIPTION
## What
Complete the revived project setup with package metadata, current documentation, contributor/security policies, a PR template, and tag-driven prebuilt binary releases.

## Why
The repository lacked licensing files, package metadata, contribution guidance, changelog conventions, security reporting instructions, and a reproducible distribution path.

## Before / after
Before: installation depended on building an unversioned Git checkout and there was no documented release process.

After: `vMAJOR.MINOR.PATCH` tags are validated against Cargo.toml, must be reachable from main, and produce checksummed Linux, macOS ARM/x86, and Windows archives on GitHub Releases. The packaging matrix also runs when the release workflow changes in a PR.

The `mrt` name is owned by an unrelated crate on crates.io, so publishing there is intentionally excluded; GitHub Releases are the viable distribution channel without renaming the package.

## Risk
- Medium
- The new release workflow is unproven until its PR packaging matrix completes; it never publishes from pull requests

## Security
- Release actions use immutable revisions
- Checkout credentials are disabled
- Tag/version/main ancestry are validated before release
- Release assets include SHA-256 checksum files
- A private vulnerability reporting route is documented

## Validation
- Full fmt, clippy, test, docs, audit, and deny suite
- `cargo package --locked --allow-dirty` including package verification
- CLI help smoke test
- YAML parsing and diff validation

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security impact reviewed
- [x] Documentation updated when needed